### PR TITLE
Add Source ID for resources

### DIFF
--- a/drafts/v1.0/MetronInfo.xsd
+++ b/drafts/v1.0/MetronInfo.xsd
@@ -43,6 +43,7 @@
             <xs:element name="Story" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
     </xs:complexType>
+    <!-- Base type to add 'id' attribute to the various resources -->
     <xs:complexType name="resourceType">
         <xs:simpleContent>
             <xs:extension base="xs:string">
@@ -66,11 +67,6 @@
     <xs:complexType name="teamsType">
         <xs:sequence>
             <xs:element name="Team" type="resourceType" minOccurs="0" maxOccurs="unbounded" />
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="genresType">
-        <xs:sequence>
-            <xs:element name="Genre" type="genreType" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="locationsType">
@@ -109,6 +105,13 @@
             <xs:element name="Credit" type="creditType" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
     </xs:complexType>
+    <xs:complexType name="roleType">
+        <xs:simpleContent>
+            <xs:extension base="roleValues">
+                <xs:attribute name="id" type="xs:positiveInteger" />
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
     <xs:complexType name="rolesType">
         <xs:sequence>
             <xs:element name="Role" type="roleType" minOccurs="0" maxOccurs="unbounded" />
@@ -119,6 +122,18 @@
             <xs:element name="Creator" type="resourceType" />
             <xs:element name="Roles" type="rolesType" minOccurs="0" />
         </xs:all>
+    </xs:complexType>
+    <xs:complexType name="genreType">
+        <xs:simpleContent>
+            <xs:extension base="genreValues">
+                <xs:attribute name="id" type="xs:positiveInteger" />
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="genresType">
+        <xs:sequence>
+            <xs:element name="Genre" type="genreType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
     </xs:complexType>
     <xs:complexType name="priceType">
         <xs:simpleContent>
@@ -168,7 +183,7 @@
             <xs:enumeration value="League of Comic Geeks" />
         </xs:restriction>
     </xs:simpleType>
-    <xs:simpleType name="roleType">
+    <xs:simpleType name="roleValues">
         <xs:restriction base="xs:string">
             <xs:enumeration value="Writer" />
             <xs:enumeration value="Script" />
@@ -214,7 +229,7 @@
             <xs:enumeration value="Other" />
         </xs:restriction>
     </xs:simpleType>
-    <xs:simpleType name="genreType">
+    <xs:simpleType name="genreValues">
         <xs:restriction base="xs:string">
             <xs:enumeration value="Adult" />
             <xs:enumeration value="Crime" />

--- a/drafts/v1.0/MetronInfo.xsd
+++ b/drafts/v1.0/MetronInfo.xsd
@@ -31,20 +31,67 @@
             <xs:element name="Pages" type="ArrayOfComicPageInfo" minOccurs="0" />
         </xs:all>
     </xs:complexType>
-    <xs:complexType name="seriesType">
-        <xs:all>
-            <xs:element name="Name" type="xs:string" />
-            <xs:element name="SortName" type="xs:string" />
-            <xs:element name="Type" type="publicationType" />
-        </xs:all>
-        <xs:attribute name="lang" type="xs:string" default="EN" />
-    </xs:complexType>
     <xs:complexType name="sourceType">
         <xs:simpleContent>
             <xs:extension base="xs:positiveInteger">
                 <xs:attribute name="source" type="informationSource" use="required" />
             </xs:extension>
         </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="storyType">
+        <xs:sequence>
+            <xs:element name="Story" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="resourceType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="id" type="xs:positiveInteger" />
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="seriesType">
+        <xs:all>
+            <xs:element name="Name" type="resourceType" />
+            <xs:element name="SortName" type="xs:string" />
+            <xs:element name="Type" type="publicationType" />
+        </xs:all>
+        <xs:attribute name="lang" type="xs:string" default="EN" />
+    </xs:complexType>
+    <xs:complexType name="charactersType">
+        <xs:sequence>
+            <xs:element name="Character" type="resourceType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="teamsType">
+        <xs:sequence>
+            <xs:element name="Team" type="resourceType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="genresType">
+        <xs:sequence>
+            <xs:element name="Genre" type="genreType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="locationsType">
+        <xs:sequence>
+            <xs:element name="Location" type="resourceType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="tagsType">
+        <xs:sequence>
+            <xs:element name="Tag" type="resourceType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="reprintType">
+        <xs:sequence>
+            <xs:element name="Name" type="resourceType" />
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="reprintsType">
+        <xs:sequence>
+            <xs:element name="Reprint" type="reprintType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
     </xs:complexType>
     <xs:complexType name="arcsType">
         <xs:sequence>
@@ -53,50 +100,9 @@
     </xs:complexType>
     <xs:complexType name="arcType">
         <xs:all>
-            <xs:element name="Name" type="xs:string" />
+            <xs:element name="Name" type="resourceType" />
             <xs:element name="Number" type="xs:positiveInteger" minOccurs="0" />
         </xs:all>
-    </xs:complexType>
-    <xs:complexType name="charactersType">
-        <xs:sequence>
-            <xs:element name="Character" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="genresType">
-        <xs:sequence>
-            <xs:element name="Genre" type="genreType" minOccurs="0" maxOccurs="unbounded" />
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="reprintType">
-        <xs:all>
-            <xs:element name="ID" type="sourceType" />
-            <xs:element name="Name" type="xs:string" />
-        </xs:all>
-    </xs:complexType>
-    <xs:complexType name="reprintsType">
-        <xs:sequence>
-            <xs:element name="Reprint" type="reprintType" minOccurs="0" maxOccurs="unbounded" />
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="storyType">
-        <xs:sequence>
-            <xs:element name="Story" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="tagsType">
-        <xs:sequence>
-            <xs:element name="Tag" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="teamsType">
-        <xs:sequence>
-            <xs:element name="Team" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-        </xs:sequence>
-    </xs:complexType>
-    <xs:complexType name="locationsType">
-        <xs:sequence>
-            <xs:element name="Location" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-        </xs:sequence>
     </xs:complexType>
     <xs:complexType name="creditsType">
         <xs:sequence>
@@ -110,7 +116,7 @@
     </xs:complexType>
     <xs:complexType name="creditType">
         <xs:all>
-            <xs:element name="Creator" type="xs:string" />
+            <xs:element name="Creator" type="resourceType" />
             <xs:element name="Roles" type="rolesType" minOccurs="0" />
         </xs:all>
     </xs:complexType>

--- a/drafts/v1.0/Sample.xml
+++ b/drafts/v1.0/Sample.xml
@@ -18,10 +18,11 @@
     <StoreDate>2011-08-31</StoreDate>
     <PageCount>32</PageCount>
     <Genres>
-        <Genre>Super-Hero</Genre>
+        <Genre id="98745">Super-Hero</Genre>
+        <Genre>Crime</Genre>
     </Genres>
     <Tags>
-        <Tag>Foo</Tag>
+        <Tag id="78945">Foo</Tag>
         <Tag>Bar</Tag>
     </Tags>
     <Arcs>
@@ -52,7 +53,7 @@
         <Team>Parademons</Team>
     </Teams>
     <Locations>
-        <Location>Gotham City</Location>
+        <Location id="12389">Gotham City</Location>
         <Location>Metropolis</Location>
     </Locations>
     <BlackAndWhite>false</BlackAndWhite>
@@ -74,7 +75,7 @@
         <Credit>
             <Creator id="32165">Geoff Johns</Creator>
             <Roles>
-                <Role>Writer</Role>
+                <Role id="32165">Writer</Role>
             </Roles>
         </Credit>
         <Credit>

--- a/drafts/v1.0/Sample.xml
+++ b/drafts/v1.0/Sample.xml
@@ -3,7 +3,7 @@
     <ID source="Comic Vine">290431</ID>
     <Publisher>DC Comics</Publisher>
     <Series lang="EN">
-        <Name>Justice League</Name>
+        <Name id="65478">Justice League</Name>
         <SortName>Justice League</SortName>
         <Type>Series</Type>
     </Series>
@@ -26,7 +26,7 @@
     </Tags>
     <Arcs>
         <Arc>
-            <Name>Origin</Name>
+            <Name id="78945">Origin</Name>
             <Number>1</Number>
         </Arc>
         <Arc>
@@ -34,7 +34,7 @@
         </Arc>
     </Arcs>
     <Characters>
-        <Character>Aquaman</Character>
+        <Character id="45678">Aquaman</Character>
         <Character>Batman</Character>
         <Character>Cyborg</Character>
         <Character>Deadman</Character>
@@ -48,7 +48,7 @@
         <Character>Wonder Woman</Character>
     </Characters>
     <Teams>
-        <Team>Justice League</Team>
+        <Team id="49948">Justice League</Team>
         <Team>Parademons</Team>
     </Teams>
     <Locations>
@@ -63,18 +63,16 @@
     <AgeRating>Everyone</AgeRating>
     <Reprints>
         <Reprint>
-            <ID source="Comic Vine">123456</ID>
-            <Name>Foo Bar #001 (2002)</Name>
+            <Name id="65498">Foo Bar #001 (2002)</Name>
         </Reprint>
         <Reprint>
-            <ID source="Comic Vine">789456</ID>
             <Name>Foo Bar #002 (2022)</Name>
         </Reprint>
     </Reprints>
     <URL>https://comicvine.gamespot.com/justice-league-1-justice-league-part-one/4000-290431/</URL>
     <Credits>
         <Credit>
-            <Creator>Geoff Johns</Creator>
+            <Creator id="32165">Geoff Johns</Creator>
             <Roles>
                 <Role>Writer</Role>
             </Roles>


### PR DESCRIPTION
Add `id` attribute for various resources (e.g. character, team), so if available might prevent duplications in a plex-like application. Fixes #6