### PR TITLE
Update Format Enum

### DIFF
--- a/drafts/v1.0/MetronInfo.xsd
+++ b/drafts/v1.0/MetronInfo.xsd
@@ -195,7 +195,7 @@
         <xs:restriction base="xs:string">
             <xs:enumeration value="Annual" />
             <xs:enumeration value="Graphic Novel" />
-            <xs:enumeration value="Limited" /> <!-- Used for mini/maxi series -->
+            <xs:enumeration value="Limited Series" /> <!-- Used for mini/maxi series -->
             <xs:enumeration value="One-Shot" />
             <xs:enumeration value="Series" /> <!-- Needs better name, but used for Ongoing/Cancelled series -->
             <xs:enumeration value="Trade Paperback" />

--- a/drafts/v1.0/MetronInfo.xsd
+++ b/drafts/v1.0/MetronInfo.xsd
@@ -199,6 +199,7 @@
             <xs:enumeration value="One-Shot" />
             <xs:enumeration value="Series" /> <!-- Needs better name, but used for Ongoing/Cancelled series -->
             <xs:enumeration value="Trade Paperback" />
+            <xs:enumeration value="Hardcover" />
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
- Add `Hardcover` enumeration to `formatType`
  -   Publishers seem to prefer this spelling which differs (for now) from Metron's SeriesType of `Hard Cover`.