### PR TITLE
Modify `ID` Element to Handle Multiple Sources

### DIFF
--- a/drafts/v1.0/MetronInfo.xsd
+++ b/drafts/v1.0/MetronInfo.xsd
@@ -5,7 +5,7 @@
     <!-- Complex Types -->
     <xs:complexType name="metroninfoType">
         <xs:all>
-            <xs:element name="ID" type="sourceType" minOccurs="0" />
+            <xs:element name="ID" type="sourcesType" minOccurs="0" />
             <xs:element name="Publisher" type="resourceType" />
             <xs:element name="Series" type="seriesType" />
             <xs:element name="CollectionTitle" type="xs:string" minOccurs="0" />
@@ -31,6 +31,15 @@
             <xs:element name="Credits" type="creditsType" minOccurs="0" />
             <xs:element name="Pages" type="ArrayOfComicPageInfo" minOccurs="0" />
         </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="sourcesType">
+        <xs:sequence>
+            <!-- The following element should be used for the primary source of metadata information. -->
+            <xs:element name="Primary" type="sourceType" />
+            <!-- The following should be used for linking to other resources for the same issue. -->
+            <xs:element name="Alternative" type="sourceType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="sourceType">

--- a/drafts/v1.0/Sample.xml
+++ b/drafts/v1.0/Sample.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <MetronInfo xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="MetronInfo.xsd">
-    <ID source="Comic Vine">290431</ID>
+    <ID>
+        <Primary source="Metron">290431</Primary>
+        <Alternative source="Comic Vine">12345</Alternative>
+        <Alternative source="Grand Comics Database">543</Alternative>
+    </ID>
     <Publisher id="12345">DC Comics</Publisher>
     <Series id="65478" lang="en">
         <Name>Justice League</Name>


### PR DESCRIPTION
Modified the `ID` element to handle multiple sources. This will allow users to identify the issue on multiple sources.

The `Primary` sub-element is used to capture where the metadata was retrieved from.

The `Alternative` sub-element is used to store the issue id from other sources.