### PR TITLE
Allow Multiple Values for URL element

### DIFF
--- a/drafts/v1.0/MetronInfo.xsd
+++ b/drafts/v1.0/MetronInfo.xsd
@@ -27,10 +27,19 @@
             <xs:element name="Reprints" type="reprintsType" minOccurs="0" />
             <xs:element name="GTIN" type="gtinType" minOccurs="0" />
             <xs:element name="AgeRating" type="ageRatingType" minOccurs="0" default="Unknown" />
-            <xs:element name="URL" type="xs:string" minOccurs="0" /> <!-- Should we make this an array? -->
+            <xs:element name="URL" type="urlsType" minOccurs="0" />
             <xs:element name="Credits" type="creditsType" minOccurs="0" />
             <xs:element name="Pages" type="ArrayOfComicPageInfo" minOccurs="0" />
         </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="urlsType">
+        <xs:sequence>
+            <!-- The following element should be for the primary source url -->
+            <xs:element name="Primary" type="xs:string" />
+            <!-- The following should be used for any additional urls -->
+            <xs:element name="Alternative" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="sourcesType">

--- a/drafts/v1.0/Sample.xml
+++ b/drafts/v1.0/Sample.xml
@@ -83,7 +83,10 @@
         <Reprint id="65498">Foo Bar #001 (2002)</Reprint>
         <Reprint>Foo Bar #002 (2022)</Reprint>
     </Reprints>
-    <URL>https://comicvine.gamespot.com/justice-league-1-justice-league-part-one/4000-290431/</URL>
+    <URL>
+        <Primary>https://comicvine.gamespot.com/justice-league-1-justice-league-part-one/4000-290431/</Primary>
+        <Alternative>https://foo.bar</Alternative>
+    </URL>
     <Credits>
         <Credit>
             <Creator id="32165">Geoff Johns</Creator>


### PR DESCRIPTION
Modify the schema to allow multiple URL values.

The `Primary` subelement is to be used for the url from the primary information source.

The `Alternative` subelements can be used for any additional urls.