### PR TITLE
Add Parent `Volume` element

### DIFF
--- a/drafts/v1.0/MetronInfo.xsd
+++ b/drafts/v1.0/MetronInfo.xsd
@@ -8,6 +8,7 @@
             <xs:element name="ID" type="sourcesType" minOccurs="0" />
             <xs:element name="Publisher" type="publisherType" />
             <xs:element name="Series" type="seriesType" />
+            <xs:element name="Volume" type="xs:positiveInteger" minOccurs="0" /> <!-- This is used for Manga -->
             <xs:element name="CollectionTitle" type="xs:string" minOccurs="0" />
             <xs:element name="Number" type="xs:string" minOccurs="0" />
             <xs:element name="Stories" type="storyType" minOccurs="0" /> <!-- Story titles in issue -->

--- a/drafts/v1.0/MetronInfo.xsd
+++ b/drafts/v1.0/MetronInfo.xsd
@@ -8,7 +8,7 @@
             <xs:element name="ID" type="sourcesType" minOccurs="0" />
             <xs:element name="Publisher" type="publisherType" />
             <xs:element name="Series" type="seriesType" />
-            <xs:element name="Volume" type="xs:positiveInteger" minOccurs="0" /> <!-- This is used for Manga -->
+            <xs:element name="Volume" type="xs:string" minOccurs="0" /> <!-- This is used for Manga -->
             <xs:element name="CollectionTitle" type="xs:string" minOccurs="0" />
             <xs:element name="Number" type="xs:string" minOccurs="0" />
             <xs:element name="Stories" type="storyType" minOccurs="0" /> <!-- Story titles in issue -->


### PR DESCRIPTION
This optional element is being added to improve support of Manga.

This differs from the US comic volume definition, which is tied to the series, so we will need to document that this is used for manga and not US comics.