### PR TITLE
Remove Genre Enums

### DIFF
--- a/drafts/v1.0/MetronInfo.xsd
+++ b/drafts/v1.0/MetronInfo.xsd
@@ -211,7 +211,7 @@
 
     <xs:complexType name="genreType">
         <xs:simpleContent>
-            <xs:extension base="genreValues">
+            <xs:extension base="xs:string">
                 <xs:attribute name="id" type="xs:positiveInteger" />
             </xs:extension>
         </xs:simpleContent>
@@ -316,25 +316,6 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="genreValues">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="Adult" />
-            <xs:enumeration value="Crime" />
-            <xs:enumeration value="Espionage" />
-            <xs:enumeration value="Fantasy" />
-            <xs:enumeration value="Historical" />
-            <xs:enumeration value="Horror" />
-            <xs:enumeration value="Humor" />
-            <xs:enumeration value="Manga" />
-            <xs:enumeration value="Parody" />
-            <xs:enumeration value="Romance" />
-            <xs:enumeration value="Science Fiction" />
-            <xs:enumeration value="Sport" />
-            <xs:enumeration value="Super-Hero" />
-            <xs:enumeration value="War" />
-            <xs:enumeration value="Western" />
-        </xs:restriction>
-    </xs:simpleType>
     <!--
         There's no governing body for age ratings, so let's use something fairly simple to cover most cases.
         It won't be perfect, but adding different values for all the different ways publishers use them seems

--- a/drafts/v1.0/Sample.xml
+++ b/drafts/v1.0/Sample.xml
@@ -39,6 +39,7 @@
     <Genres>
         <Genre id="98745">Super-Hero</Genre>
         <Genre>Crime</Genre>
+        <Genre>Foo Bar</Genre>
     </Genres>
     <Tags>
         <Tag id="78945">Foo</Tag>


### PR DESCRIPTION
Use a string element instead of an enum for genres. There seems to be not enough consensus around using an enum.