### PR TITLE
Add addition enums to `ageRatingType` 

### DIFF
--- a/drafts/v1.0/MetronInfo.xsd
+++ b/drafts/v1.0/MetronInfo.xsd
@@ -323,6 +323,8 @@
             <xs:enumeration value="Teen" /> <!-- Appropriate for readers age 12 and older. -->
             <xs:enumeration value="Teen Plus" /> <!-- Appropriate for readers age 15 and older. -->
             <xs:enumeration value="Mature" /> <!-- Appropriate for readers age 17 and older. -->
+            <xs:enumeration value="Explicit" /> <!-- Contains Gore, Sexually Explicit material that would be more extreme than R rating -->
+            <xs:enumeration value="Adult" /> <!-- Likely pornographic in nature -->
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Extending the age enumerations to include `Explicit` and `Adult`.

These values where decided upon in #47