### PR TITLE
ComicRack Community Edition support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ exist with the `ComicInfo.xml` schema.
 
 ## Rationale
 
-The `ComicInfo.xml` schema was designed for the needs of ComicRack Application (which for all intents is a dead
-project), and supports a fairly limited amount of data. Some benefits of a new schema would include:
+The `ComicInfo.xml` schema was designed for the needs of ComicRack Application ~~(which for all intents is a dead
+project)~~, and supports a fairly limited amount of data. Some benefits of a new schema would include:
 
 - Additional `Elements` for information. (e.g. Price, Global Trade Item Numbers, Series Type, etc.)
 - Better handling of data types. Instead of using delimited strings for list items, we can use Arrays of `Elements`.
@@ -67,6 +67,7 @@ Currently, the following software does:
   Metron Comic Book Database.
 - [Perdoo](https://github.com/Buried-In-Code/Perdoo) - Commandline tool to tag and organize comics from multiple sources
   (Metron, Comicvine & Marvel)
+- [ComicRack Community Edition](https://github.com/maforget/ComicRackCE) - Revival of the ComicRack software, supports reading metroninfo metadata.
 
 If you are a developer that has added support for MetronInfo.xml to your software, please create a PR to update the
 README


### PR DESCRIPTION
- I've added the mention that ComicRack Community Edition reads the `MetronInfo.xml`.
- Striked out the mention of ComicRack being dead.

Since the `ComicInfo.xml` is is just a representation of the internal values of ComicRack, additional fields are not supported. I don't know if I will support any of them, because I don't want to change the program too much. So for now the support for `MetronInfo.xml` is read only and I only mapped the field to the ComicInfo as best I could.

Note: Since the internal is still ComicInfo, support is only when `ComicInfo.xml` doesn't exists.
