### PR TITLE
Remove Unnecessary Type Definition `genreType`

### DIFF
--- a/drafts/v1.1/MetronInfo.xsd
+++ b/drafts/v1.1/MetronInfo.xsd
@@ -204,17 +204,9 @@
         </xs:all>
     </xs:complexType>
 
-    <xs:complexType name="genreType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="id" type="xs:string" />
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-
     <xs:complexType name="genresType">
         <xs:sequence>
-            <xs:element name="Genre" type="genreType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="Genre" type="resourceType" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
     </xs:complexType>
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,26 +3,38 @@ from pathlib import Path
 import pytest
 from xmlschema import XMLSchema11, XMLSchemaValidationError
 
-TEST_XSD = Path(__file__).parent.parent / "schema" / "v1.0" / "MetronInfo.xsd"
+TEST_V10_XSD = Path(__file__).parent.parent / "schema" / "v1.0" / "MetronInfo.xsd"
+TEST_V11_XSD = Path(__file__).parent.parent / "drafts" / "v1.1" / "MetronInfo.xsd"
 TEST_FILES_PATH = Path(__file__).parent / "test_files" / "v1.0"
 
 
 @pytest.mark.parametrize(
     ("xsd", "xml"),
     [
-        (TEST_XSD, TEST_FILES_PATH / "valid.xml"),
+        (TEST_V10_XSD, TEST_FILES_PATH / "valid.xml"),
         (
-            TEST_XSD,
+                TEST_V10_XSD,
             '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
             "<Series><Name>Foo</Name></Series><Number /><PageCount>0</PageCount></MetronInfo>",
         ),
         (
-            TEST_XSD,
+                TEST_V10_XSD,
             '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
             "<Series><Name>Foo</Name><Volume>0</Volume></Series><Number /></MetronInfo>",
         ),
+        (TEST_V11_XSD, TEST_FILES_PATH / "valid.xml"),
+        (
+                TEST_V10_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number /><PageCount>0</PageCount></MetronInfo>",
+        ),
+        (
+                TEST_V10_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name><Volume>0</Volume></Series><Number /></MetronInfo>",
+        ),
     ],
-    ids=["valid_xml", "zero_page_count", "volume_zero"],
+    ids=["valid_xml", "zero_page_count", "volume_zero", "v11_valid_xml", "v11_zero_page_count", "v11_volume_zero"],
 )
 def test_valid(xsd: Path, xml: Path | str) -> None:
     schema = XMLSchema11(xsd)
@@ -32,19 +44,30 @@ def test_valid(xsd: Path, xml: Path | str) -> None:
 @pytest.mark.parametrize(
     ("xsd", "xml"),
     [
-        (TEST_XSD, TEST_FILES_PATH / "dup_primary_attr.xml"),
+        (TEST_V10_XSD, TEST_FILES_PATH / "dup_primary_attr.xml"),
         (
-            TEST_XSD,
+                TEST_V10_XSD,
             '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
             "<Series><Name>Foo</Name></Series><Number /><PageCount>-1</PageCount></MetronInfo>",
         ),
         (
-            TEST_XSD,
+                TEST_V10_XSD,
             '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
             "<Series><Name>Foo</Name><Volume>-1</Volume></Series><Number /></MetronInfo>",
         ),
+        (TEST_V11_XSD, TEST_FILES_PATH / "dup_primary_attr.xml"),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number /><PageCount>-1</PageCount></MetronInfo>",
+        ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name><Volume>-1</Volume></Series><Number /></MetronInfo>",
+        ),
     ],
-    ids=["dup_primary_attr_xml", "negative_page_count", "negative_volume"],
+    ids=["dup_primary_attr_xml", "negative_page_count", "negative_volume", "v11_dup_primary_attr_xml", "v11_negative_page_count", "v11_negative_volume" ],
 )
 def test_invalid(xsd: Path, xml: Path | str) -> None:
     schema = XMLSchema11(xsd)


### PR DESCRIPTION
This PR simply removes a redundant type definition `genreType` which is the same as `resourceType`