### PR TITLE
Add `comicbox` & `codex` to list of software support MetronInfo.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Currently, the following software does:
   (Metron, Comicvine & Marvel)
 - [ComicRack Community Edition](https://github.com/maforget/ComicRackCE) - Revival of the ComicRack software, supports reading metroninfo metadata.
 - [metroninfo_ct ](https://github.com/mizaki/metroninfo_ct) - A [Comictagger](https://github.com/comictagger/comictagger) plugin to write MetronInfo.xml metadata.
+- [Comicbox](https://github.com/ajslater/comicbox) - A comic metadata reading & writing library.
+- [Codex](https://github.com/ajslater/codex) - A web based comic archive browser and reader 
 
 If you are a developer that has added support for MetronInfo.xml to your software, please create a PR to update the
 README


### PR DESCRIPTION
This PR simply add `comicbox` & `codex` to list of supported software.