### PR TITLE
Add optional CommunityRating element to v1.1 schema

### DIFF
--- a/drafts/v1.1/MetronInfo.xsd
+++ b/drafts/v1.1/MetronInfo.xsd
@@ -29,6 +29,7 @@
             <xs:element name="Reprints" type="reprintsType" minOccurs="0" />
             <xs:element name="GTIN" type="gtinType" minOccurs="0" />
             <xs:element name="AgeRating" type="ageRatingType" minOccurs="0" default="Unknown" />
+            <xs:element name="CommunityRating" type="communityRatingType" minOccurs="0" />
             <xs:element name="URLs" type="urlsType" minOccurs="0" />
             <xs:element name="Credits" type="creditsType" minOccurs="0" />
             <xs:element name="LastModified" type="xs:dateTime" minOccurs="0" />
@@ -232,6 +233,13 @@
         </xs:all>
     </xs:complexType>
 
+    <xs:complexType name="communityRatingType">
+        <xs:all>
+            <xs:element name="AverageRating" type="averageRatingType" />
+            <xs:element name="RatingCount" type="xs:positiveInteger" minOccurs="0" />
+        </xs:all>
+    </xs:complexType>
+
     <!-- Simple Types -->
     <xs:simpleType name="formatType">
         <xs:restriction base="xs:string">
@@ -323,6 +331,13 @@
             <xs:enumeration value="Mature" /> <!-- Appropriate for readers age 17 and older. -->
             <xs:enumeration value="Explicit" /> <!-- Contains Gore, Sexually Explicit material that would be more extreme than R rating -->
             <xs:enumeration value="Adult" /> <!-- Likely pornographic in nature -->
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="averageRatingType">
+        <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="0" />
+            <xs:maxInclusive value="5.0" />
         </xs:restriction>
     </xs:simpleType>
 

--- a/drafts/v1.1/Sample.xml
+++ b/drafts/v1.1/Sample.xml
@@ -91,6 +91,10 @@
         <UPC>76194130593600111</UPC>
     </GTIN>
     <AgeRating>Everyone</AgeRating>
+    <CommunityRating>
+        <AverageRating>4.5</AverageRating>
+        <RatingCount>1250</RatingCount>
+    </CommunityRating>
     <Reprints>
         <Reprint id="65498">Foo Bar #001 (2002)</Reprint>
         <Reprint>Foo Bar #002 (2022)</Reprint>

--- a/tests/test.py
+++ b/tests/test.py
@@ -44,6 +44,27 @@ TEST_FILES_PATH = Path(__file__).parent / "test_files" / "v1.0"
                 '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
                 "<Series><Name>Foo</Name></Series><Number>1</Number><PageCount>0</PageCount></MetronInfo>",
         ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number />"
+                "<CommunityRating><AverageRating>4.5</AverageRating><RatingCount>1250</RatingCount></CommunityRating>"
+                "</MetronInfo>",
+        ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number />"
+                "<CommunityRating><AverageRating>0</AverageRating></CommunityRating>"
+                "</MetronInfo>",
+        ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number />"
+                "<CommunityRating><AverageRating>5.0</AverageRating></CommunityRating>"
+                "</MetronInfo>",
+        ),
     ],
     ids=[
         "valid_xml",
@@ -54,6 +75,9 @@ TEST_FILES_PATH = Path(__file__).parent / "test_files" / "v1.0"
         "v11_volume_zero",
         "v11_alternative_number",
         "v11_alternative_number_absent",
+        "v11_community_rating",
+        "v11_community_rating_min",
+        "v11_community_rating_max",
     ],
 )
 def test_valid(xsd: Path, xml: Path | str) -> None:
@@ -92,6 +116,34 @@ def test_valid(xsd: Path, xml: Path | str) -> None:
                 "<Series><Name>Foo</Name></Series><Number>1</Number>"
                 "<AlternativeNumber>1A</AlternativeNumber><AlternativeNumber>1B</AlternativeNumber></MetronInfo>",
         ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number />"
+                "<CommunityRating><AverageRating>5.1</AverageRating></CommunityRating>"
+                "</MetronInfo>",
+        ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number />"
+                "<CommunityRating><AverageRating>-0.1</AverageRating></CommunityRating>"
+                "</MetronInfo>",
+        ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number />"
+                "<CommunityRating><RatingCount>100</RatingCount></CommunityRating>"
+                "</MetronInfo>",
+        ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number />"
+                "<CommunityRating><AverageRating>4.5</AverageRating><RatingCount>0</RatingCount></CommunityRating>"
+                "</MetronInfo>",
+        ),
     ],
     ids=[
         "dup_primary_attr_xml",
@@ -101,6 +153,10 @@ def test_valid(xsd: Path, xml: Path | str) -> None:
         "v11_negative_page_count",
         "v11_negative_volume",
         "v11_duplicate_alternative_number",
+        "v11_community_rating_too_high",
+        "v11_community_rating_negative",
+        "v11_community_rating_missing_average",
+        "v11_community_rating_zero_count",
     ],
 )
 def test_invalid(xsd: Path, xml: Path | str) -> None:


### PR DESCRIPTION
## Summary
- Add optional `CommunityRating` element to the v1.1 schema, containing:
  - `AverageRating` (required, `xs:decimal` restricted to 0–5.0)
  - `RatingCount` (optional, `xs:positiveInteger`)
- Update `drafts/v1.1/Sample.xml` with an example `CommunityRating` block
- Add schema validation tests covering valid boundary values (0, 5.0, with/without `RatingCount`) and invalid cases (out-of-range rating, missing required `AverageRating`, zero `RatingCount`)

Closes #83
