### PR TITLE
Add AlternativeNumber element to v1.1 schema

### DIFF
--- a/drafts/v1.1/MetronInfo.xsd
+++ b/drafts/v1.1/MetronInfo.xsd
@@ -11,6 +11,7 @@
             <xs:element name="MangaVolume" type="xs:string" minOccurs="0" /> <!-- This is used for Manga -->
             <xs:element name="CollectionTitle" type="xs:string" minOccurs="0" />
             <xs:element name="Number" type="xs:string" minOccurs="0" />
+            <xs:element name="AlternativeNumber" type="xs:string" minOccurs="0" />
             <xs:element name="Stories" type="storyType" minOccurs="0" /> <!-- Story titles in issue -->
             <xs:element name="Summary" type="xs:string" minOccurs="0" />
             <xs:element name="Prices" type="pricesType" minOccurs="0" />

--- a/tests/test.py
+++ b/tests/test.py
@@ -33,8 +33,28 @@ TEST_FILES_PATH = Path(__file__).parent / "test_files" / "v1.0"
                 '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
                 "<Series><Name>Foo</Name><Volume>0</Volume></Series><Number /></MetronInfo>",
         ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number>1</Number>"
+                "<AlternativeNumber>1A</AlternativeNumber><PageCount>0</PageCount></MetronInfo>",
+        ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number>1</Number><PageCount>0</PageCount></MetronInfo>",
+        ),
     ],
-    ids=["valid_xml", "zero_page_count", "volume_zero", "v11_valid_xml", "v11_zero_page_count", "v11_volume_zero"],
+    ids=[
+        "valid_xml",
+        "zero_page_count",
+        "volume_zero",
+        "v11_valid_xml",
+        "v11_zero_page_count",
+        "v11_volume_zero",
+        "v11_alternative_number",
+        "v11_alternative_number_absent",
+    ],
 )
 def test_valid(xsd: Path, xml: Path | str) -> None:
     schema = XMLSchema11(xsd)
@@ -66,8 +86,22 @@ def test_valid(xsd: Path, xml: Path | str) -> None:
                 '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
                 "<Series><Name>Foo</Name><Volume>-1</Volume></Series><Number /></MetronInfo>",
         ),
+        (
+                TEST_V11_XSD,
+                '<?xml version="1.0" encoding="UTF-8"?><MetronInfo>'
+                "<Series><Name>Foo</Name></Series><Number>1</Number>"
+                "<AlternativeNumber>1A</AlternativeNumber><AlternativeNumber>1B</AlternativeNumber></MetronInfo>",
+        ),
     ],
-    ids=["dup_primary_attr_xml", "negative_page_count", "negative_volume", "v11_dup_primary_attr_xml", "v11_negative_page_count", "v11_negative_volume" ],
+    ids=[
+        "dup_primary_attr_xml",
+        "negative_page_count",
+        "negative_volume",
+        "v11_dup_primary_attr_xml",
+        "v11_negative_page_count",
+        "v11_negative_volume",
+        "v11_duplicate_alternative_number",
+    ],
 )
 def test_invalid(xsd: Path, xml: Path | str) -> None:
     schema = XMLSchema11(xsd)


### PR DESCRIPTION
## Summary
- Adds an optional `AlternativeNumber` string element to the v1.1 draft schema, placed alongside the existing `Number` element.
- Adds tests covering the element's presence, absence, and duplicate-element validation.

## Why
Marvel and DC (and some other publishers) occasionally publish issues with a legacy or alternate numbering scheme in addition to the primary issue number (e.g. a title relaunches at `#1` while also carrying over its "legacy" numbering from a prior volume). `AlternativeNumber` gives metadata consumers a place to record that secondary number without overloading the `Number` element.

Closes #67
